### PR TITLE
get directory size with PHP

### DIFF
--- a/index.php
+++ b/index.php
@@ -804,6 +804,17 @@ function system_get_total_size($path){
         if (system_exec_cmd('du -sb '.$path,$output)){
             $total_size = floatval(substr($output,0,strpos($output,"\t")));
         }
+        else{
+            $total_size = 0;
+            $path = realpath($path);
+            if(is_dir($path)){
+                foreach(new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS)) as $object){
+                    if ( !is_link($object) ){
+                        $total_size += $object->getSize();
+                    }
+                }
+            }
+        }
     }
     if ($total_size === false) fb_log('system_get_total_size("'.$path.'") = FALSE');
     else fb_log('system_get_total_size("'.$path.'") = '.format_size($total_size));

--- a/index.php
+++ b/index.php
@@ -807,8 +807,8 @@ function system_get_total_size($path){
         else{
             $total_size = 0;
             $path = realpath($path);
-            if(is_dir($path)){
-                foreach(new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS)) as $object){
+            if(is_dir($path) && is_readable($path)){
+                foreach(new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),RecursiveIteratorIterator::LEAVES_ONLY,  RecursiveIteratorIterator::CATCH_GET_CHILD) as $object){
                     if ( !is_link($object) ){
                         $total_size += $object->getSize();
                     }


### PR DESCRIPTION
Some hosting might not allow `system_exec_cmd`. In that case fall back to a pure php way of getting the size. Idea came from [stackowerflow](https://stackoverflow.com/questions/478121/how-to-get-directory-size-in-php/21409562#21409562)