### PR TITLE
Updating is_binary function

### DIFF
--- a/index.php
+++ b/index.php
@@ -2168,13 +2168,18 @@ function frame2(){
     echo "</body>\n</html>";
 }
 function is_binary($file){
-    //https://stackoverflow.com/questions/1765311/how-to-view-files-in-binary-from-bash
-    //http://php.net/manual/pt_BR/function.bin2hex.php
     if (!is_file($file)) return false;
-    $mime = mime_content_type($file);
-    fb_log($file,$mime);
-    if (strpos($mime,'text') === false && strpos($mime,'x-empty') === false) return true;
-    return false;
+    // If mbstring is supported, we check if the file has encoding (meaning it's text)
+    if (function_exists('mb_detect_encoding')) {
+        $content = file_get_contents($file);
+        return mb_detect_encoding($content, null, true) === false;
+    } else {
+    // Fallback on legacy check
+        $mime = mime_content_type($file);
+        fb_log($file,$mime);
+        if (strpos($mime,'text') === false && strpos($mime,'x-empty') === false) return true;
+        return false;
+    }
 }
 function is_textfile($file){
     if (!is_file($file)) return false;

--- a/index.php
+++ b/index.php
@@ -2168,11 +2168,15 @@ function frame2(){
     echo "</body>\n</html>";
 }
 function is_binary($file){
-    if (!is_file($file)) return false;
-    // If mbstring is supported, we check if the file has encoding (meaning it's text)
+    if (!is_file($file) || !is_readable($filePath)) return false;
+    // If mbstring is supported, we check if the first chunk of the file has encoding (meaning it's text)
     if (function_exists('mb_detect_encoding')) {
+        $handle = fopen($file, "rb");
+        if (!$handle) return false;
+        $chunk = fread($handle, 512);
+        fclose($handle);
         $content = file_get_contents($file);
-        return mb_detect_encoding($content, null, true) === false;
+        return mb_detect_encoding((string) $chunk, null, true) === false;
     } else {
     // Fallback on legacy check
         $mime = mime_content_type($file);


### PR DESCRIPTION
Resolve issue #70 

The current function check  if "text" or "x-empty" is in the mimetype to determine if it's a binary or not.
We have some files flagged as `application/javascript` that are considered as binary even if they are not.

This PR correct it by relying on file encoding.
The flaw is that it depends on mbstring (might not be installed everywhere) so the legacy function is still here for fallback.

